### PR TITLE
feat: 일반 리뷰 편집 기능 구현

### DIFF
--- a/src/app/actions/restaurant.ts
+++ b/src/app/actions/restaurant.ts
@@ -196,3 +196,42 @@ export const updateRestaurantShareCount = async (restaurantId: number) => {
 
   return data;
 };
+
+export const getStandardReviewById = async (reviewId: number) => {
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+  const res = await fetch(
+    `${backendUrl}/restaurants/review/standard/${reviewId}`,
+  );
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.message || '에러 발생');
+  }
+
+  return data;
+};
+
+export const updateStandardReview = async (
+  reviewData: StandardReviewPayload,
+  reviewId: number,
+) => {
+  const accessToken = cookies().get('accessToken')?.value;
+  const refreshToken = cookies().get('refreshToken')?.value;
+
+  const serverApi = createServerApi(accessToken, refreshToken);
+
+  try {
+    const res = await serverApi.patch(
+      `/restaurants/review/standard/${reviewId}`,
+      reviewData,
+    );
+
+    return { success: true, data: res.data };
+  } catch (error: any) {
+    if (error.name === 'RefreshTokenExpired') {
+      return { success: false, reason: 'UNAUTHORIZED' };
+    }
+    return { success: false, reason: 'UNKNOWN_ERROR' };
+  }
+};

--- a/src/app/mypage/review/page.tsx
+++ b/src/app/mypage/review/page.tsx
@@ -6,7 +6,8 @@ import StoryPreview from '@/app/restaurant/[id]/review/_components/StoryPreview'
 import { useAuthStore } from '@/store/authStore';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 const FILTERS = ['전체', '승인완료', '승인대기', '승인거절'];
 const PERIODS = [
@@ -21,8 +22,36 @@ const page = () => {
     'all' | 'graphic' | 'standard'
   >('all');
   const [receiptFilter, setReceiptFilter] = useState<string>('전체');
+  const [openDropdownId, setOpenDropdownId] = useState<number | null>(null);
   const [period, setPeriod] = useState<string>('전체');
   const { user } = useAuthStore();
+  const router = useRouter();
+
+  // 드롭다운 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      // 드롭다운 버튼이나 드롭다운 메뉴 내부를 클릭한 경우는 무시
+      if (target.closest('[data-dropdown]')) {
+        return;
+      }
+
+      if (openDropdownId !== null) {
+        setOpenDropdownId(null);
+      }
+    };
+
+    if (openDropdownId !== null) {
+      // mousedown 대신 click 이벤트 사용하고 약간의 지연 추가
+      setTimeout(() => {
+        document.addEventListener('click', handleClickOutside);
+      }, 0);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [openDropdownId]);
 
   const { data: reviewData, isPending } = useQuery({
     queryKey: ['reviews', reviewFilter],
@@ -136,21 +165,63 @@ const page = () => {
 
             <div className="mt-[12px] flex flex-col items-center gap-[15px] pb-[12px] md:grid md:grid-cols-3">
               {filteredReviews?.map((review: any, index: number) => (
-                <div className="mt-[1px] h-[330px] px-[20px] md:px-0">
-                  <div
-                    key={review.id || index}
-                    className="h-[330px] w-[247px] overflow-hidden rounded-[12px] bg-white shadow-[0px_0px_4px_0px_rgba(0,0,0,0.15)]"
-                  >
+                <div
+                  className="mt-[1px] h-[330px] px-[20px] md:px-0"
+                  key={review.id}
+                >
+                  <div className="h-[330px] w-[247px] overflow-hidden rounded-[12px] bg-white shadow-[0px_0px_4px_0px_rgba(0,0,0,0.15)]">
                     {review.type === 'standard' && (
                       <div className="relative flex h-full flex-col">
                         <div className="relative flex h-[208px] flex-col rounded-t-[12px] bg-[#FCFCFD] p-3">
-                          <Image
-                            src="/assets/icons/more.svg"
-                            alt="more"
-                            width={24}
-                            height={24}
-                            className="absolute right-3 top-3"
-                          />
+                          <div className="relative w-full">
+                            <Image
+                              src="/assets/icons/more.svg"
+                              alt="more"
+                              width={24}
+                              height={24}
+                              className="absolute right-0 top-0 z-10 cursor-pointer"
+                              onClick={() =>
+                                setOpenDropdownId(
+                                  openDropdownId === review.id
+                                    ? null
+                                    : review.id,
+                                )
+                              }
+                            />
+
+                            {openDropdownId === review.id && (
+                              <div
+                                data-dropdown
+                                className="absolute right-0 top-[23px] z-20 w-[100px] rounded-[8px] border border-[#E2E2E4] bg-white shadow-[0px_2px_8px_0px_rgba(0,0,0,0.15)]"
+                              >
+                                <button
+                                  className="w-full rounded-t-[8px] px-[12px] py-[8px] text-left text-[14px] font-normal text-[#171719] hover:bg-[#F5F5F5]"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    setOpenDropdownId(null);
+                                    // 리뷰 편집 페이지로 이동
+                                    console.log('in');
+                                    router.push(
+                                      `/restaurant/${review.restaurant_id}/review/standard?edit=${review.id}`,
+                                    );
+                                  }}
+                                >
+                                  편집하기
+                                </button>
+                                <div className="h-[1px] bg-[#E2E2E4]"></div>
+                                <button
+                                  className="w-full rounded-b-[8px] px-[12px] py-[8px] text-left text-[14px] font-normal text-[#FF3B30] hover:bg-[#F5F5F5]"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    // 삭제 기능 구현
+                                    setOpenDropdownId(null);
+                                  }}
+                                >
+                                  삭제하기
+                                </button>
+                              </div>
+                            )}
+                          </div>
 
                           {/* 리뷰 텍스트 */}
                           <div className="mt-[40px] h-[72px] w-full rounded-[12px] border border-[#E2E2E4] px-[10px] py-[20px]">
@@ -163,6 +234,7 @@ const page = () => {
                           <div className="mt-[14px] flex items-center">
                             {[1, 2, 3, 4, 5].map((n) => (
                               <Star
+                                key={review.id + n}
                                 width={15}
                                 height={15}
                                 filled={n <= review.rating}

--- a/src/app/restaurant/[id]/review/_components/MultiPhotoUpload.tsx
+++ b/src/app/restaurant/[id]/review/_components/MultiPhotoUpload.tsx
@@ -25,6 +25,9 @@ const MultiPhotoUpload = ({
     };
   }, [photos]);
 
+  // 전체 사진 목록
+  const totalPhotoCount = photos.length;
+
   const getPhotoCellRadius = (index: number) => {
     const radiusMap = {
       0: 'rounded-tl-[12px]',
@@ -61,7 +64,7 @@ const MultiPhotoUpload = ({
           />
           <span className="mt-[4px] font-semibold">사진 추가</span>
           <span className="mt-[2px] font-medium">
-            {photos.length}/{MAX_PHOTOS}
+            {totalPhotoCount}/{MAX_PHOTOS}
           </span>
           <input
             type="file"
@@ -72,7 +75,7 @@ const MultiPhotoUpload = ({
           />
         </label>
 
-        {photos.length === 0 ? (
+        {totalPhotoCount === 0 ? (
           <div className="my-auto flex h-[214px] w-[222px] items-center justify-center rounded-[20px] bg-[#E5E6E8] text-[14px] font-semibold text-white md:text-[10px] lg:text-[16px]">
             예시 확인하기
           </div>
@@ -81,6 +84,7 @@ const MultiPhotoUpload = ({
             {Array.from({ length: MAX_PHOTOS }).map((_, index) => {
               const file = photos[index];
               const photoUrl = photoUrls[index];
+
               return (
                 <div
                   key={index}

--- a/src/app/restaurant/[id]/review/standard/page.tsx
+++ b/src/app/restaurant/[id]/review/standard/page.tsx
@@ -3,13 +3,15 @@
 import {
   createStandardReview,
   getRestaurantInfoAndMenus,
+  getStandardReviewById,
+  updateStandardReview,
 } from '@/app/actions/restaurant';
 import { Calendar } from '@/components/ui/calendar';
 import { useAuthStore } from '@/store/authStore';
 import { StandardReviewPayload } from '@/types/restaurant';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import KeywordSelection from '../_components/KeywordSelection';
 import MultiPhotoUpload from '../_components/MultiPhotoUpload';
 import RestaurantInfo from '../_components/RestaurantInfo';
@@ -27,6 +29,10 @@ type StandardReviewPageProps = {
 
 const StandardReviewForm = ({ params }: StandardReviewPageProps) => {
   const restaurantId = params.id;
+  const searchParams = useSearchParams();
+  const editReviewId = searchParams.get('edit');
+  const isEditMode = !!editReviewId;
+
   const [visitDate, setVisitDate] = useState<Date | undefined>(new Date());
   const [visitTime, setVisitTime] = useState<string>('');
   const [receiptImage, setReceiptImage] = useState<string | File | null>(null);
@@ -43,9 +49,65 @@ const StandardReviewForm = ({ params }: StandardReviewPageProps) => {
     queryFn: () => getRestaurantInfoAndMenus(restaurantId),
   });
 
+  // 편집 모드일 때 기존 리뷰 데이터 불러오기
+  const { data: existingReviewData, isPending: isReviewLoading } = useQuery({
+    queryKey: ['review', editReviewId],
+    queryFn: () => getStandardReviewById(Number(editReviewId)),
+    enabled: isEditMode && !!editReviewId,
+  });
+
+  // 기존 리뷰 데이터를 폼에 채워넣기
+  useEffect(() => {
+    if (existingReviewData?.data?.review) {
+      const review = existingReviewData.data.review;
+      const photos = existingReviewData.data.photos || [];
+      const receiptVerifications =
+        existingReviewData.data.receipt_verifications || [];
+
+      setContent(review.content || '');
+      setRating(review.rating || 0);
+      setKeywords(review.keywords || []);
+      setVisitTime(review.visited_time_slot || '');
+
+      // 방문 날짜 설정
+      if (review.visited_date) {
+        setVisitDate(new Date(review.visited_date));
+      }
+
+      // 기존 사진들을 File 객체로 변환하여 photos에 저장
+      const convertPhotosToFiles = async () => {
+        const photoFiles = await Promise.all(
+          photos.map(async (photo: any) => {
+            const response = await fetch(photo.image_url);
+            const blob = await response.blob();
+            const file = new File([blob], `existing_${photo.id}.jpg`, {
+              type: blob.type,
+            });
+            // 기존 사진 ID를 파일 객체에 저장
+            (file as any).existingId = photo.id;
+            return file;
+          }),
+        );
+        setPhotos(photoFiles);
+      };
+
+      convertPhotosToFiles();
+
+      // 영수증 사진 설정 (receipt_verifications 배열에서)
+      if (receiptVerifications.length > 0) {
+        const receiptPhoto = receiptVerifications[0];
+        setReceiptImage(receiptPhoto.image_url);
+      } else {
+        setReceiptImage(null);
+      }
+    }
+  }, [existingReviewData]);
+
   const { mutateAsync: submitReview, isPending: isSubmitting } = useMutation({
     mutationFn: (payload: StandardReviewPayload) =>
-      createStandardReview(payload),
+      isEditMode
+        ? updateStandardReview(payload, Number(editReviewId))
+        : createStandardReview(payload),
     onSuccess: async (result, variables) => {
       if (!result.success) {
         if (result.reason === 'UNAUTHORIZED') {
@@ -54,7 +116,7 @@ const StandardReviewForm = ({ params }: StandardReviewPageProps) => {
           router.push('/signin');
           return;
         }
-        alert('리뷰 등록 실패');
+        alert(isEditMode ? '리뷰 수정 실패' : '리뷰 등록 실패');
         return;
       }
 
@@ -65,17 +127,20 @@ const StandardReviewForm = ({ params }: StandardReviewPageProps) => {
         queryClient.invalidateQueries({
           queryKey: ['restaurant', restaurantId],
         }),
+        queryClient.invalidateQueries({
+          queryKey: ['reviews'],
+        }),
       ]);
 
-      alert('리뷰 등록 성공');
+      alert(isEditMode ? '리뷰 수정 성공' : '리뷰 등록 성공');
       router.push(`/restaurant/${restaurantId}`);
     },
     onError: () => {
-      alert('리뷰 등록 실패');
+      alert(isEditMode ? '리뷰 수정 실패' : '리뷰 등록 실패');
     },
   });
 
-  if (isPending) return <div>로딩 중…</div>;
+  if (isPending || (isEditMode && isReviewLoading)) return <div>로딩 중…</div>;
   if (error) return <div>에러 발생: {error.message}</div>;
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -224,7 +289,7 @@ const StandardReviewForm = ({ params }: StandardReviewPageProps) => {
           disabled={isSubmitting}
           className="flex h-[37px] w-[68px] items-center justify-center rounded-[8px] bg-[#FA4D09] px-[20px] py-[8px] text-[16px] font-medium leading-[130%] text-white disabled:opacity-60"
         >
-          등록
+          {isEditMode ? '수정' : '등록'}
         </button>
       </div>
     </form>


### PR DESCRIPTION
## 📌 feat: 일반 리뷰 편집 기능 구현

---

## ✨ 변경 사항

- [x] 주요 기능 추가/수정
- [ ] 버그 수정
- [ ] 성능 개선
- [ ] 기타 변경 사항

---

## 🔍 변경 내용

1. 편집 모드 감지 및 데이터 로딩
• URL 쿼리 파라미터 edit 으로 편집 모드 감지
• getStandardReviewById API로 기존 리뷰 데이터 불러오기
• 기존 사진들을 File 객체로 변환하여 photos 상태에 저장

2. 기존 데이터 폼에 채워넣기
• 리뷰 내용, 별점, 키워드, 방문 날짜/시간 설정
• 음식 사진: data.photos 배열에서 가져와서 File 객체로 변환
• 영수증 사진: data. receipt_verifications 배열에서 가져와서 URL로 설정

3. 편집/생성 API 분기 처리
• 편집 모드: updateStanda rdReview API 사용
• 생성 모드: createstandardReview API 사용


---

## ✅ 확인 사항

- [X] 코드는 로컬에서 테스트(DEV 환경)를 완료했습니다.
- [x] 코드는 로컬에서 테스트(BUILD 환경)를 완료했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰를 위해 충분히 설명이 포함되어 있습니다.

---

## 💡 추가 참고 사항

<!-- 코드 리뷰어가 알아야 할 추가 사항이 있다면 여기에 작성하세요 -->

---
